### PR TITLE
Delete Meetings directory as redundant

### DIFF
--- a/Meetings/README.md
+++ b/Meetings/README.md
@@ -1,1 +1,0 @@
-## Meetings README


### PR DESCRIPTION
## Delete Meetings directory as redundant

Gov-HOLON meetings are now recorded in the repository discussion boards at https://github.com/NFT-DAO/Governance-HOLON/discussions/categories/meetings